### PR TITLE
Yuki/refine response endpoint

### DIFF
--- a/Response/router.js
+++ b/Response/router.js
@@ -49,7 +49,8 @@ router.post("/response", async (req, res, next) => {
 				? Number(currentLevel)
 				: Number(currentLevel) + 1
 		// find questionIds of answers already in the test
-		const questionIds = answers.map(answer => answer.questionId)
+		const updatedAnswers = await test.getAnswers()
+		const questionIds = updatedAnswers.map(answer => answer.questionId)
 		// find all questions of newLevel excluding the ones already in questionIds
 
 		const questions = await Question.findAll({

--- a/Response/router.js
+++ b/Response/router.js
@@ -55,7 +55,8 @@ router.post("/response", async (req, res, next) => {
 			where: {
 				initialLevel: nextLevel,
 				id: { [Op.notIn]: questionIds }
-			}
+			},
+			include: [Answer]
 		})
 		// send back a random one
 		const question = questions[Math.floor(Math.random() * questions.length)]

--- a/Response/router.js
+++ b/Response/router.js
@@ -21,9 +21,11 @@ router.post("/response", async (req, res, next) => {
 		const test = await Test.findByPk(testId)
 		const answers = await test.getAnswers()
 		// find the current answer provided
-		const currentAnswer = await Answer.findByPk(answerId, {
-			include: [Question]
-		})
+		const currentAnswer = isNaN(Number(answerId))
+			? null
+			: await Answer.findByPk(Number(answerId), {
+					include: [Question]
+			  })
 
 		// if currentAnswer does not exist, this is the first attempt to get a question
 		// there is an old answer to the same question


### PR DESCRIPTION
response endpoint send back a random question that also include answers
(easier for the front end to display)
response endpoint used to possibly give back to back same question
(now refined the find questions also exclude the most recent added response)
if passing an invalid datatype (not integer) in the answerId query params, sequelize will error
(now if passing a invalide string to answerId, treat it as no answerId was provided)
(of course this need to be more refined consider if someone taking the test want to keep an answer empty and comeback to edit it later"